### PR TITLE
Implement InputStream and OutputStream wrappers for socket oriented apps

### DIFF
--- a/src/com/felhr/usbserial/SerialInputStream.java
+++ b/src/com/felhr/usbserial/SerialInputStream.java
@@ -1,0 +1,46 @@
+package com.felhr.usbserial;
+
+import java.io.InputStream;
+import java.util.concurrent.ArrayBlockingQueue;
+
+public class SerialInputStream extends InputStream implements UsbSerialInterface.UsbReadCallback {
+	protected final UsbSerialInterface device;
+	protected ArrayBlockingQueue data = new ArrayBlockingQueue<Integer>(256);
+	protected volatile boolean is_open;
+
+	public SerialInputStream(UsbSerialInterface device) {
+		this.device = device;
+		is_open = true;
+		device.read(this);
+	}
+
+	@Override public int read() {
+		while (is_open) {
+			try {
+				return (Integer)data.take();
+			} catch (InterruptedException e) {
+				// ignore, will be retried by while loop
+			}
+		}
+		return -1;
+	}
+
+	public void close() {
+		is_open = false;
+		try {
+			data.put(-1);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void onReceivedData(byte[] new_data) {
+		for (byte b : new_data) {
+			try {
+				data.put(((int)b) & 0xff);
+			} catch (InterruptedException e) {
+				// ignore, possibly losing bytes when buffer is full
+			}
+		}
+	}
+}

--- a/src/com/felhr/usbserial/SerialOutputStream.java
+++ b/src/com/felhr/usbserial/SerialOutputStream.java
@@ -1,0 +1,20 @@
+package com.felhr.usbserial;
+
+import java.io.OutputStream;
+import java.util.Arrays;
+
+public class SerialOutputStream extends OutputStream {
+	protected final UsbSerialInterface device;
+
+	public SerialOutputStream(UsbSerialInterface device) {
+		this.device = device;
+	}
+
+	@Override public void write(int b) {
+		device.write(new byte[] { (byte)b });
+	}
+
+	@Override public void write(byte[] b) {
+		device.write(b);
+	}
+}


### PR DESCRIPTION
Hi,

it's awesome to see that there is finally a library supporting more than one brand of USB serial adapters. For [my app](https://aprsdroid.org/) I needed an InputStream/OutputStream based API.

I wanted to ask if you would accept these as a pull request. The implementation is rather straight-forward, with a queue-based input stream and simple forwarding outputter.