### PR TITLE
Fixed close in CDCSerialDevice to enable reset on Arduino Leonardo/Micro

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/CDCSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CDCSerialDevice.java
@@ -37,8 +37,8 @@ public class CDCSerialDevice extends UsbSerialDevice
             (byte) 0x08  // bDataBits (8)
     };
 
-    private static final int CDC_DEFAULT_CONTROL_LINE = 0x0003;
-    private static final int CDC_DISCONNECT_CONTROL_LINE = 0x0002;
+    private static final int CDC_CONTROL_LINE_ON = 0x0003;
+    private static final int CDC_CONTROL_LINE_OFF = 0x0000;
 
     private UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
@@ -92,7 +92,7 @@ public class CDCSerialDevice extends UsbSerialDevice
 
         // Default Setup
         setControlCommand(CDC_SET_LINE_CODING, 0, CDC_DEFAULT_LINE_CODING);
-        setControlCommand(CDC_SET_CONTROL_LINE_STATE, CDC_DEFAULT_CONTROL_LINE, null);
+        setControlCommand(CDC_SET_CONTROL_LINE_STATE, CDC_CONTROL_LINE_ON, null);
 
         // Initialize UsbRequest
         requestIN = new UsbRequest();
@@ -111,9 +111,11 @@ public class CDCSerialDevice extends UsbSerialDevice
     @Override
     public void close()
     {
+        setControlCommand(CDC_SET_CONTROL_LINE_STATE, CDC_CONTROL_LINE_OFF, null);
         killWorkingThread();
         killWriteThread();
         connection.releaseInterface(mInterface);
+        connection.close();
     }
 
     @Override


### PR DESCRIPTION
Felipe, this is the pull request for enabling the reset on the Arduiono Micro. I also needed to add the connection.close() to enable opens after the close when I added the DTR toggling. 