### PR TITLE
Code cleanup and bugfixes in CP2102SerialDevice.java

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/CH34xSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CH34xSerialDevice.java
@@ -174,73 +174,52 @@ public class CH34xSerialDevice extends UsbSerialDevice
     @Override
     public void setBaudRate(int baudRate)
     {
+        int ret;
         if(baudRate <= 300)
         {
-            int ret = setBaudRate(CH34X_300_1312, CH34X_300_0f2c); //300
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_300_1312, CH34X_300_0f2c); //300
         }else if(baudRate > 300  && baudRate <= 600)
         {
-            int ret = setBaudRate(CH34X_600_1312, CH34X_600_0f2c); //600
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_600_1312, CH34X_600_0f2c); //600
 
         }else if(baudRate > 600 && baudRate <= 1200)
         {
-            int ret = setBaudRate(CH34X_1200_1312, CH34X_1200_0f2c); //1200
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_1200_1312, CH34X_1200_0f2c); //1200
         }else if(baudRate > 1200 && baudRate <=2400)
         {
-            int ret = setBaudRate(CH34X_2400_1312, CH34X_2400_0f2c); //2400
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_2400_1312, CH34X_2400_0f2c); //2400
         }else if(baudRate > 2400 && baudRate <= 4800)
         {
-            int ret = setBaudRate(CH34X_4800_1312, CH34X_4800_0f2c); //4800
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_4800_1312, CH34X_4800_0f2c); //4800
         }else if(baudRate > 4800 && baudRate <= 9600)
         {
-            int ret = setBaudRate(CH34X_9600_1312, CH34X_9600_0f2c); //9600
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_9600_1312, CH34X_9600_0f2c); //9600
         }else if(baudRate > 9600 && baudRate <= 19200)
         {
-            int ret = setBaudRate(CH34X_19200_1312, CH34X_19200_0f2c_rest); //19200
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_19200_1312, CH34X_19200_0f2c_rest); //19200
         }else if(baudRate > 19200 && baudRate <= 38400)
         {
-            int ret = setBaudRate(CH34X_38400_1312, CH34X_19200_0f2c_rest); //38400
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_38400_1312, CH34X_19200_0f2c_rest); //38400
         }else if(baudRate > 38400 && baudRate <= 57600)
         {
-            int ret = setBaudRate(CH34X_57600_1312, CH34X_19200_0f2c_rest); //57600
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_57600_1312, CH34X_19200_0f2c_rest); //57600
         }else if(baudRate > 57600 && baudRate <= 115200) //115200
         {
-            int ret = setBaudRate(CH34X_115200_1312, CH34X_19200_0f2c_rest);
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_115200_1312, CH34X_19200_0f2c_rest);
         }else if(baudRate > 115200 && baudRate <= 230400) //230400
         {
-            int ret = setBaudRate(CH34X_230400_1312, CH34X_19200_0f2c_rest);
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_230400_1312, CH34X_19200_0f2c_rest);
         }else if(baudRate > 230400 && baudRate <= 460800) //460800
         {
-            int ret = setBaudRate(CH34X_460800_1312, CH34X_19200_0f2c_rest);
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_460800_1312, CH34X_19200_0f2c_rest);
         }else if(baudRate > 460800 && baudRate <= 921600)
         {
-            int ret = setBaudRate(CH34X_921600_1312, CH34X_19200_0f2c_rest);
-            if(ret == -1)
-                Log.i(CLASS_ID, "SetBaudRate failed!");
+            ret = setBaudRate(CH34X_921600_1312, CH34X_19200_0f2c_rest);
         }
+        else
+            ret = -1;
+        if (ret == -1)
+           Log.i(CLASS_ID, "SetBaudRate failed! Baudrate:" + Integer.toString(baudRate));
     }
 
     @Override
@@ -260,26 +239,28 @@ public class CH34xSerialDevice extends UsbSerialDevice
     @Override
     public void setParity(int parity)
     {
+        int iParity;
         switch(parity)
         {
             case UsbSerialInterface.PARITY_NONE:
-                setCh340xParity(CH34X_PARITY_NONE);
+                iParity = CH34X_PARITY_NONE;
                 break;
             case UsbSerialInterface.PARITY_ODD:
-                setCh340xParity(CH34X_PARITY_ODD);
+                iParity = CH34X_PARITY_ODD;
                 break;
             case UsbSerialInterface.PARITY_EVEN:
-                setCh340xParity(CH34X_PARITY_EVEN);
+                iParity = CH34X_PARITY_EVEN;
                 break;
             case UsbSerialInterface.PARITY_MARK:
-                setCh340xParity(CH34X_PARITY_MARK);
+                iParity = CH34X_PARITY_MARK;
                 break;
             case UsbSerialInterface.PARITY_SPACE:
-                setCh340xParity(CH34X_PARITY_SPACE);
+                iParity = CH34X_PARITY_SPACE;
                 break;
             default:
-                break;
+                return;
         }
+        setCh340xParity(iParity);
     }
 
     @Override

--- a/usbserial/src/main/java/com/felhr/usbserial/CP2102SerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CP2102SerialDevice.java
@@ -173,94 +173,79 @@ public class CP2102SerialDevice extends UsbSerialDevice
     @Override
     public void setDataBits(int dataBits)
     {
-        byte[] data = getCTL();
+        int iBitmask;
         switch(dataBits)
         {
             case UsbSerialInterface.DATA_BITS_5:
-                data[1] = 5;
+                iBitmask = 5;
                 break;
             case UsbSerialInterface.DATA_BITS_6:
-                data[1] = 6;
+                iBitmask = 6;
                 break;
             case UsbSerialInterface.DATA_BITS_7:
-                data[1] = 7;
+                iBitmask = 7;
                 break;
             case UsbSerialInterface.DATA_BITS_8:
-                data[1] = 8;
+                iBitmask = 8;
                 break;
             default:
                 return;
         }
-        byte wValue = (byte) ((data[1] << 8) | (data[0] & 0xFF));
-        setControlCommand(CP210x_SET_LINE_CTL, wValue, null);
+        byte[] data = getCTL();
+        int wValue = ((iBitmask << 8) | data[0]);
+        setControlCommand(CP210x_SET_LINE_CTL, wValue, null); // byte 1
 
     }
 
     @Override
     public void setStopBits(int stopBits)
     {
-        byte[] data = getCTL();
+        int iBitmask;
         switch(stopBits)
         {
             case UsbSerialInterface.STOP_BITS_1:
-                data[0] &= ~1;
-                data[0] &= ~(1 << 1);
+                iBitmask = 0x0; // 000
                 break;
             case UsbSerialInterface.STOP_BITS_15:
-                data[0] |= 1;
-                data[0] &= ~(1 << 1) ;
+                iBitmask = 0x1; // 001
                 break;
             case UsbSerialInterface.STOP_BITS_2:
-                data[0] &= ~1;
-                data[0] |= (1 << 1);
+                iBitmask = 0x2; // 010
                 break;
             default:
                 return;
         }
-        byte wValue = (byte) ((data[1] << 8) | (data[0] & 0xFF));
+        byte[] data = getCTL();
+        int wValue = (data[1] << 8) | ((data[0]&(~0x7)) | iBitmask); // byte 0, clear and assign (2) bits 0, 1
         setControlCommand(CP210x_SET_LINE_CTL, wValue, null);
     }
 
     @Override
     public void setParity(int parity)
     {
-        byte[] data = getCTL();
+        int iBitmask;
         switch(parity)
         {
             case UsbSerialInterface.PARITY_NONE:
-                data[0] &= ~(1 << 4);
-                data[0] &= ~(1 << 5);
-                data[0] &= ~(1 << 6);
-                data[0] &= ~(1 << 7);
+                iBitmask = 0x0; // 0000
                 break;
             case UsbSerialInterface.PARITY_ODD:
-                data[0] |= (1 << 4);
-                data[0] &= ~(1 << 5);
-                data[0] &= ~(1 << 6);
-                data[0] &= ~(1 << 7);
+                iBitmask = 0x1; // 0001
                 break;
             case UsbSerialInterface.PARITY_EVEN:
-                data[0] &= ~(1 << 4);
-                data[0] |= (1 << 5);
-                data[0] &= ~(1 << 6);
-                data[0] &= ~(1 << 7);
+                iBitmask = 0x2; // 0010
                 break;
             case UsbSerialInterface.PARITY_MARK:
-                data[0] |= (1 << 4);
-                data[0] |= (1 << 5);
-                data[0] &= ~(1 << 6);
-                data[0] &= ~(1 << 7);
+                iBitmask = 0x3; // 0011
                 break;
             case UsbSerialInterface.PARITY_SPACE:
-                data[0] &= ~(1 << 4);
-                data[0] &= ~(1 << 5);
-                data[0] |= (1 << 6);
-                data[0] &= ~(1 << 7);
+                iBitmask = 0x4; // 0100
                 break;
             default:
                 return;
         }
-        byte wValue =  (byte) ((data[1] << 8) | (data[0] & 0xFF));
+        byte[] data = getCTL();
+        int wValue = (data[1] << 8) | ((data[0]&(~(0xF << 4))) | (iBitmask << 4)); // byte 0, clear and assign (4) bits 4, 5, 6, 7
         setControlCommand(CP210x_SET_LINE_CTL, wValue, null);
     }
 

--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -61,6 +61,7 @@ public class FTDISerialDevice extends UsbSerialDevice
     private static final int FTDI_SET_MODEM_CTRL_DEFAULT3 = 0x0100;
     private static final int FTDI_SET_MODEM_CTRL_DEFAULT4 = 0x0200;
     private static final int FTDI_SET_FLOW_CTRL_DEFAULT = 0x0000;
+    private static final int FTDI_SET_FLOW_CTRL_XON_XOFF = 0x1311;
 
     private int currentSioSetData = 0x0000;
 
@@ -209,179 +210,134 @@ public class FTDISerialDevice extends UsbSerialDevice
     @Override
     public void setDataBits(int dataBits)
     {
+        int iBitmask;
         switch(dataBits)
         {
             case UsbSerialInterface.DATA_BITS_5:
-                currentSioSetData |= 1;
-                currentSioSetData &= ~(1 << 1);
-                currentSioSetData |= (1 << 2);
-                currentSioSetData &= ~(1 << 3);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x5;  // 0101
                 break;
             case UsbSerialInterface.DATA_BITS_6:
-                currentSioSetData &= ~1;
-                currentSioSetData |= (1 << 1);
-                currentSioSetData |= (1 << 2);
-                currentSioSetData &= ~(1 << 3);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x6;  // 0110
                 break;
             case UsbSerialInterface.DATA_BITS_7:
-                currentSioSetData |= 1;
-                currentSioSetData |= (1 << 1);
-                currentSioSetData |= (1 << 2);
-                currentSioSetData &= ~(1 << 3);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x7;  // 0111
                 break;
             case UsbSerialInterface.DATA_BITS_8:
-                currentSioSetData &= ~1;
-                currentSioSetData &= ~(1 << 1);
-                currentSioSetData &= ~(1 << 2);
-                currentSioSetData |= (1 << 3);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x8;  // 1000
                 break;
             default:
-                currentSioSetData &= ~1;
-                currentSioSetData &= ~(1 << 1);
-                currentSioSetData &= ~(1 << 2);
-                currentSioSetData |= (1 << 3);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x8;  // 1000
                 break;
         }
-
+        currentSioSetData = (currentSioSetData &(~0xF)) | iBitmask;  // clear and assign (4) bits 0, 1, 2, 3
+        setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
     }
 
     @Override
     public void setStopBits(int stopBits)
     {
+        int iBitmask;
         switch(stopBits)
         {
             case UsbSerialInterface.STOP_BITS_1:
-                currentSioSetData &= ~(1 << 11);
-                currentSioSetData &= ~(1 << 12);
-                currentSioSetData &= ~(1 << 13);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x0;  // 000
                 break;
             case UsbSerialInterface.STOP_BITS_15:
-                currentSioSetData |= (1 << 11);
-                currentSioSetData &= ~(1 << 12);
-                currentSioSetData &= ~(1 << 13);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x1;  // 001
                 break;
             case UsbSerialInterface.STOP_BITS_2:
-                currentSioSetData &= ~(1 << 11);
-                currentSioSetData |= (1 << 12);
-                currentSioSetData &= ~(1 << 13);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x2;  // 010
                 break;
             default:
-                currentSioSetData &= ~(1 << 11);
-                currentSioSetData &= ~(1 << 12);
-                currentSioSetData &= ~(1 << 13);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x0;  // 000
         }
-
+        currentSioSetData = (currentSioSetData&(~(0x7 << 11))) | (iBitmask << 11); // clear and assign (3) bits 11, 12, 13
+        setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
     }
 
     @Override
     public void setParity(int parity)
     {
+        int iBitmask;
         switch(parity)
         {
             case UsbSerialInterface.PARITY_NONE:
-                currentSioSetData &= ~(1 << 8);
-                currentSioSetData &= ~(1 << 9);
-                currentSioSetData &= ~(1 << 10);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x0;  // 000
                 break;
             case UsbSerialInterface.PARITY_ODD:
-                currentSioSetData |= (1 << 8);
-                currentSioSetData &= ~(1 << 9);
-                currentSioSetData &= ~(1 << 10);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x1;  // 001
                 break;
             case UsbSerialInterface.PARITY_EVEN:
-                currentSioSetData &= ~(1 << 8);
-                currentSioSetData |= (1 << 9);
-                currentSioSetData &= ~(1 << 10);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x2;  // 010
                 break;
             case UsbSerialInterface.PARITY_MARK:
-                currentSioSetData |= (1 << 8);
-                currentSioSetData |= (1 << 9);
-                currentSioSetData &= ~(1 << 10);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x3;  // 011
                 break;
             case UsbSerialInterface.PARITY_SPACE:
-                currentSioSetData &= ~(1 << 8);
-                currentSioSetData &= ~(1 << 9);
-                currentSioSetData |= (1 << 10);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x4;  // 100
                 break;
             default:
-                currentSioSetData &= ~(1 << 8);
-                currentSioSetData &= ~(1 << 9);
-                currentSioSetData &= ~(1 << 10);
-                setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
+                iBitmask = 0x0;  // 000
                 break;
         }
-
+        currentSioSetData = (currentSioSetData&(~(0x7 << 8))) | (iBitmask << 8); // clear and assign (3) bits 8, 9, 10
+        setControlCommand(FTDI_SIO_SET_DATA, currentSioSetData, 0, null);
     }
 
     @Override
     public void setFlowControl(int flowControl)
     {
+        int iIndexCommand;
+        int iValue = FTDI_SET_FLOW_CTRL_DEFAULT;
         switch(flowControl)
         {
             case UsbSerialInterface.FLOW_CONTROL_OFF:
-                setControlCommand(FTDI_SIO_SET_FLOW_CTRL, FTDI_SET_FLOW_CTRL_DEFAULT, 0, null);
+                iIndexCommand = 0x0; // OFF
+                setControlCommand(FTDI_SIO_SET_FLOW_CTRL, FTDI_SET_FLOW_CTRL_DEFAULT, iIndexCommand, null);
                 rtsCtsEnabled = false;
                 dtrDsrEnabled = false;
-                break;
+                return;
             case UsbSerialInterface.FLOW_CONTROL_RTS_CTS:
                 rtsCtsEnabled = true;
                 dtrDsrEnabled = false;
-                int indexRTSCTS = 0x0001;
-                setControlCommand(FTDI_SIO_SET_FLOW_CTRL, FTDI_SET_FLOW_CTRL_DEFAULT, indexRTSCTS, null);
+                iIndexCommand = 0x1; // RTSCTS
                 break;
             case UsbSerialInterface.FLOW_CONTROL_DSR_DTR:
                 dtrDsrEnabled = true;
                 rtsCtsEnabled = false;
-                int indexDSRDTR = 0x0002;
-                setControlCommand(FTDI_SIO_SET_FLOW_CTRL, FTDI_SET_FLOW_CTRL_DEFAULT, indexDSRDTR , null);
+                iIndexCommand = 0x2; // DSRDTR
                 break;
             case UsbSerialInterface.FLOW_CONTROL_XON_XOFF:
-                int indexXONXOFF = 0x0004;
-                int wValue = 0x1311;
-                setControlCommand(FTDI_SIO_SET_FLOW_CTRL, wValue, indexXONXOFF , null);
+                iIndexCommand = 0x4; // XONXOFF
+                iValue = FTDI_SET_FLOW_CTRL_XON_XOFF;
                 break;
             default:
-                setControlCommand(FTDI_SIO_SET_FLOW_CTRL, FTDI_SET_FLOW_CTRL_DEFAULT, 0, null);
+                iIndexCommand = 0x0; // OFF
                 break;
         }
+        setControlCommand(FTDI_SIO_SET_FLOW_CTRL, iValue, iIndexCommand, null);
     }
 
     @Override
     public void setRTS(boolean state)
     {
+        int iRtsState;
         if(state)
-        {
-            setControlCommand(FTDI_SIO_MODEM_CTRL, FTDI_SIO_SET_RTS_HIGH, 0, null);
-        }else
-        {
-            setControlCommand(FTDI_SIO_MODEM_CTRL, FTDI_SIO_SET_RTS_LOW, 0, null);
-        }
+           iRtsState = FTDI_SIO_SET_RTS_HIGH;
+        else
+           iRtsState = FTDI_SIO_SET_RTS_LOW;
+        setControlCommand(FTDI_SIO_MODEM_CTRL, iRtsState, 0, null);
     }
 
     @Override
     public void setDTR(boolean state)
     {
+        int iDtrState;
         if(state)
-        {
-            setControlCommand(FTDI_SIO_MODEM_CTRL, FTDI_SIO_SET_DTR_HIGH, 0, null);
-        }else
-        {
-            setControlCommand(FTDI_SIO_MODEM_CTRL, FTDI_SIO_SET_DTR_LOW, 0, null);
-        }
+           iDtrState = FTDI_SIO_SET_DTR_HIGH;
+        else
+           iDtrState = FTDI_SIO_SET_DTR_LOW;
+        setControlCommand(FTDI_SIO_MODEM_CTRL, iDtrState, 0, null);
     }
 
     @Override
@@ -471,11 +427,8 @@ public class FTDISerialDevice extends UsbSerialDevice
 
     private int setControlCommand(int request, int value, int index, byte[] data)
     {
-        int dataLength = 0;
-        if(data != null)
-        {
-            dataLength = data.length;
-        }
+        int dataLength = (data == null) ? 0 : data.length;
+
         int response = connection.controlTransfer(FTDI_REQTYPE_HOST2DEVICE, request, value, mInterface.getId() + 1 + index, data, dataLength, USB_TIMEOUT);
         Log.i(CLASS_ID,"Control Transfer Response: " + String.valueOf(response));
         return response;

--- a/usbserial/src/main/java/com/felhr/usbserial/PL2303SerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/PL2303SerialDevice.java
@@ -132,117 +132,85 @@ public class PL2303SerialDevice extends UsbSerialDevice
     @Override
     public void setDataBits(int dataBits)
     {
+        byte byteSetLine6;
         switch(dataBits)
         {
             case UsbSerialInterface.DATA_BITS_5:
-                if(defaultSetLine[6] != 0x05)
-                {
-                    defaultSetLine[6] = 0x05;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine6 = 0x05;
                 break;
             case UsbSerialInterface.DATA_BITS_6:
-                if(defaultSetLine[6] != 0x06)
-                {
-                    defaultSetLine[6] = 0x06;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine6 = 0x06;
                 break;
             case UsbSerialInterface.DATA_BITS_7:
-                if(defaultSetLine[6] != 0x07)
-                {
-                    defaultSetLine[6] = 0x07;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine6 = 0x07;
                 break;
             case UsbSerialInterface.DATA_BITS_8:
-                if(defaultSetLine[6] != 0x08)
-                {
-                    defaultSetLine[6] = 0x08;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine6 = 0x08;
                 break;
             default:
                 return;
         }
-
+        if (defaultSetLine[6] != byteSetLine6)
+        {
+             defaultSetLine[6] = byteSetLine6;
+             setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
+        }
     }
 
     @Override
     public void setStopBits(int stopBits)
     {
+        byte byteSetLine4;
         switch(stopBits)
         {
             case UsbSerialInterface.STOP_BITS_1:
-                if(defaultSetLine[4] != 0x00)
-                {
-                    defaultSetLine[4] = 0x00;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine4 = 0x00;
                 break;
             case UsbSerialInterface.STOP_BITS_15:
-                if(defaultSetLine[4] != 0x01)
-                {
-                    defaultSetLine[4] = 0x01;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine4 = 0x01;
                 break;
             case UsbSerialInterface.STOP_BITS_2:
-                if(defaultSetLine[4] != 0x02)
-                {
-                    defaultSetLine[4] = 0x02;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine4 = 0x02;
                 break;
             default:
                 return;
+        }
+        if (defaultSetLine[4] != byteSetLine4)
+        {
+             defaultSetLine[4] = byteSetLine4;
+             setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
         }
     }
 
     @Override
     public void setParity(int parity)
     {
+        byte byteSetLine5;
         switch(parity)
         {
             case UsbSerialInterface.PARITY_NONE:
-                if(defaultSetLine[5] != 0x00)
-                {
-                    defaultSetLine[5] = 0x00;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine5 = 0x00;
                 break;
             case UsbSerialInterface.PARITY_ODD:
-                if(defaultSetLine[5] != 0x01)
-                {
-                    defaultSetLine[5] = 0x01;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine5 = 0x01;
                 break;
             case UsbSerialInterface.PARITY_EVEN:
-                if(defaultSetLine[5] != 0x02)
-                {
-                    defaultSetLine[5] = 0x02;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine5 = 0x02;
                 break;
             case UsbSerialInterface.PARITY_MARK:
-                if(defaultSetLine[5] != 0x03)
-                {
-                    defaultSetLine[5] = 0x03;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine5 = 0x03;
                 break;
             case UsbSerialInterface.PARITY_SPACE:
-                if(defaultSetLine[5] != 0x04)
-                {
-                    defaultSetLine[5] = 0x04;
-                    setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
-                }
+                byteSetLine5 = 0x04;
                 break;
             default:
                 return;
         }
-
+        if (defaultSetLine[5] != byteSetLine5)
+        {
+             defaultSetLine[5] = byteSetLine5;
+             setControlCommand(PL2303_REQTYPE_HOST2DEVICE, PL2303_SET_LINE_CODING, 0x0000, 0, defaultSetLine);
+        }
     }
 
     @Override


### PR DESCRIPTION
Bugfixes in CP2102SerialDevice.java (setDataBits, setStopBits and setParity) and code cleanup/simplification in CP2102SerialDevice.java, CH34xSerialDevice.java, PL2303SerialDevice.java and FTDISerialDevice.java
