### PR TITLE
Feature/initial baud rate

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -112,6 +112,30 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             serialBuffer.putWriteBuffer(buffer);
     }
 
+    /**
+     * <p>
+     *     Use this setter <strong>before</strong> calling {@link #open()} to override the default baud rate defined in this particular class.
+     * </p>
+     *
+     * <p>
+     *     This is a workaround for devices where calling {@link #setBaudRate(int)} has no effect once {@link #open()} has been called.
+     * </p>
+     *
+     * @param initialBaudRate baud rate to be used when initializing the serial connection
+     */
+    public void setInitialBaudRate(int initialBaudRate) {
+        // this class does not implement initialBaudRate
+    }
+
+    /**
+     * Classes that do not implement {@link #setInitialBaudRate(int)} should always return -1
+     *
+     * @return initial baud rate used when initializing the serial connection
+     */
+    public int getInitialBaudRate() {
+        return -1;
+    }
+
     @Override
     public int read(UsbReadCallback mCallback)
     {


### PR DESCRIPTION
It appears that once a serial connection is open calling setBaudRate has no effect:.
(Observed on a geniune Arduino/CDCSerialDevice and a clone NHduino/CH34xSerialDevice. See the #91 issue.)
This patch provides following:
commit 8c6969b: added a no-op getter and setter to UsbSerialDevice where subclasses may implement the support for setting the initial baud rate to override the class-specified (hard-coded) default baud rate
commit b32cbb5: implemented support for the initial baud rate for CDCSerialDevice (geniune Arduino Uno among others)