### PR TITLE
Internal USB Crash

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/CDCSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CDCSerialDevice.java
@@ -8,6 +8,8 @@ import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
 import android.util.Log;
 
+import com.felhr.utils.SafeUsbRequest;
+
 public class CDCSerialDevice extends UsbSerialDevice
 {
     private static final String CLASS_ID = CDCSerialDevice.class.getSimpleName();
@@ -64,7 +66,7 @@ public class CDCSerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new UsbRequest();
+            requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/CH34xSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CH34xSerialDevice.java
@@ -14,6 +14,8 @@ import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
 import android.util.Log;
 
+import com.felhr.utils.SafeUsbRequest;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CH34xSerialDevice extends UsbSerialDevice
@@ -116,7 +118,7 @@ public class CH34xSerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new UsbRequest();
+            requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/CP2102SerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CP2102SerialDevice.java
@@ -8,6 +8,8 @@ import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
 import android.util.Log;
 
+import com.felhr.utils.SafeUsbRequest;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CP2102SerialDevice extends UsbSerialDevice
@@ -101,7 +103,7 @@ public class CP2102SerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new UsbRequest();
+            requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -10,6 +10,8 @@ import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
 import android.util.Log;
 
+import com.felhr.utils.SafeUsbRequest;
+
 public class FTDISerialDevice extends UsbSerialDevice
 {
     private static final String CLASS_ID = FTDISerialDevice.class.getSimpleName();
@@ -115,7 +117,7 @@ public class FTDISerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new UsbRequest();
+            requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/PL2303SerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/PL2303SerialDevice.java
@@ -8,6 +8,8 @@ import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
 import android.util.Log;
 
+import com.felhr.utils.SafeUsbRequest;
+
 public class PL2303SerialDevice extends UsbSerialDevice
 {
     private static final String CLASS_ID = PL2303SerialDevice.class.getSimpleName();
@@ -62,7 +64,7 @@ public class PL2303SerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new UsbRequest();
+            requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/utils/SafeUsbRequest.java
+++ b/usbserial/src/main/java/com/felhr/utils/SafeUsbRequest.java
@@ -1,0 +1,34 @@
+package com.felhr.utils;
+
+import android.hardware.usb.UsbRequest;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+
+
+public class SafeUsbRequest extends UsbRequest
+{
+    static final String usbRqBufferField = "mBuffer";
+    static final String usbRqLengthField = "mLength";
+
+    @Override
+    public boolean queue(ByteBuffer buffer, int length)
+    {
+        Field usbRequestBuffer;
+        Field usbRequestLength;
+        try
+        {
+            usbRequestBuffer = UsbRequest.class.getDeclaredField(usbRqBufferField);
+            usbRequestLength = UsbRequest.class.getDeclaredField(usbRqLengthField);
+            usbRequestBuffer.setAccessible(true);
+            usbRequestLength.setAccessible(true);
+            usbRequestBuffer.set(this, buffer);
+            usbRequestLength.set(this, length);
+        } catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        return super.queue(buffer, length);
+    }
+}


### PR DESCRIPTION
Fixes crash at line android.hardware.usb.UsbRequest.dequeue (UsbRequest.java:156), an internal Android bug. Was actually implemented by @felHR85 in the original bug #40, but this PR is rebased to the latest.