### PR TITLE
Fix intermittent crashes with buffer reads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -149,7 +149,7 @@ public class SerialBuffer
                     e.printStackTrace();
                 }
             }
-            if(position <= -1 ) return new byte[DEFAULT_READ_BUFFER_SIZE];
+            if(position <= -1 ) return new byte[0];
             byte[] dst =  Arrays.copyOfRange(buffer, 0, position);
             if(debugging)
                 UsbSerialDebugger.printLogGet(dst, true);

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -149,9 +149,7 @@ public class SerialBuffer
                     e.printStackTrace();
                 }
             }
-            if(position <= -1 ) {
-                return new byte[DEFAULT_READ_BUFFER_SIZE];
-            }
+            if(position <= -1 ) return new byte[DEFAULT_READ_BUFFER_SIZE];
             byte[] dst =  Arrays.copyOfRange(buffer, 0, position);
             if(debugging)
                 UsbSerialDebugger.printLogGet(dst, true);

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -148,7 +148,8 @@ public class SerialBuffer
                     e.printStackTrace();
                 }
             }
-            byte[] dst =  Arrays.copyOfRange(buffer, 0, position);
+            int to = position <= -1 ? 0 : position;
+            byte[] dst =  Arrays.copyOfRange(buffer, 0, to);
             if(debugging)
                 UsbSerialDebugger.printLogGet(dst, true);
             position = -1;

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -118,6 +118,7 @@ public class SerialBuffer
 
         public synchronized void put(byte[] src)
         {
+            if(src == null || src.length == 0) return;
             if(position == -1)
                 position = 0;
             if(debugging)

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -148,8 +148,10 @@ public class SerialBuffer
                     e.printStackTrace();
                 }
             }
-            int to = position <= -1 ? 0 : position;
-            byte[] dst =  Arrays.copyOfRange(buffer, 0, to);
+            if(position <= -1 ) {
+                return new byte[DEFAULT_READ_BUFFER_SIZE];
+            }
+            byte[] dst =  Arrays.copyOfRange(buffer, 0, position);
             if(debugging)
                 UsbSerialDebugger.printLogGet(dst, true);
             position = -1;

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -304,7 +304,8 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             while(working.get())
             {
                 byte[] data = serialBuffer.getWriteBuffer();
-                connection.bulkTransfer(outEndpoint, data, data.length, USB_TIMEOUT);
+                if(data.length > 0)
+                    connection.bulkTransfer(outEndpoint, data, data.length, USB_TIMEOUT);
             }
         }
 

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSpiDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSpiDevice.java
@@ -99,7 +99,8 @@ public abstract class UsbSpiDevice implements UsbSpiInterface
             while(working.get())
             {
                 byte[] data = serialBuffer.getWriteBuffer();
-                connection.bulkTransfer(outEndpoint, data, data.length, USB_TIMEOUT);
+                if(data.length > 0)
+                    connection.bulkTransfer(outEndpoint, data, data.length, USB_TIMEOUT);
             }
         }
 


### PR DESCRIPTION
It seems there are some cases that the `from` value for
Arrays#copyOfRange is `-1` or less. This causes it to throw
`IllegalArgumentException`. To naively solve this issue,
make sure the `to` argument is `0` or more.

@felHR85 thoughts if you've time.