### PR TITLE
InputStream integer return fixes.

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/SerialInputStream.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialInputStream.java
@@ -42,7 +42,7 @@ public class SerialInputStream extends InputStream
         int ret = device.syncRead(buffer, timeout);
         if(ret >= 0) {
             bufferSize = ret;
-            return buffer[pointer++];
+            return buffer[pointer++] & 0xff;
         }else {
             return -1;
         }
@@ -68,7 +68,7 @@ public class SerialInputStream extends InputStream
 
     private int checkFromBuffer(){
         if(bufferSize > 0 && pointer < bufferSize){
-            return buffer[pointer++];
+            return buffer[pointer++] & 0xff;
         }else{
             pointer = 0;
             bufferSize = -1;


### PR DESCRIPTION
Fix one condition where read returns a large negative integer instead of the correct byte value. 
Fix a second condition where checkFromBuffer returns a negative number and triggers a serial read before the buffer is depleted.

For example, if 0xFE is read from the buffer, Setting an integer equal to the buffer value results in 0xFFFFFFFE, which is out of the byte range.