### PR TITLE
Add missing unregisterReceiver(usbReceiver) call

### DIFF
--- a/example/src/main/java/com/felhr/serialportexample/UsbService.java
+++ b/example/src/main/java/com/felhr/serialportexample/UsbService.java
@@ -155,6 +155,7 @@ public class UsbService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        unregisterReceiver(usbReceiver);
         UsbService.SERVICE_CONNECTED = false;
     }
 

--- a/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
+++ b/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
@@ -126,6 +126,7 @@ public class UsbService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        unregisterReceiver(usbReceiver);
         UsbService.SERVICE_CONNECTED = false;
     }
 

--- a/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
+++ b/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
@@ -156,6 +156,7 @@ public class UsbService extends Service {
     @Override
     public void onDestroy() {
         super.onDestroy();
+        unregisterReceiver(usbReceiver);
         UsbService.SERVICE_CONNECTED = false;
     }
 


### PR DESCRIPTION
Added unregisterReceiver(usbReceiver) to onDestroy() in UsbService.java of three examples:
- example
- exampleStreams
- exampleSync

Please refer to issue #188 
