### PR TITLE
Ensure findSerialPortDevice() requests access ONLY to a supported device

### DIFF
--- a/example/src/main/java/com/felhr/serialportexample/UsbService.java
+++ b/example/src/main/java/com/felhr/serialportexample/UsbService.java
@@ -175,31 +175,39 @@ public class UsbService extends Service {
         // This snippet will try to open the first encountered usb device connected, excluding usb root hubs
         HashMap<String, UsbDevice> usbDevices = usbManager.getDeviceList();
         if (!usbDevices.isEmpty()) {
-            boolean keep = true;
+            
+            // first, dump the hashmap for diagnostic purposes
+            for (Map.Entry<String, UsbDevice> entry : usbDevices.entrySet()) {
+                device = entry.getValue();
+                Log.d(TAG, String.format("USBDevice.HashMap (vid:pid) (%X:%X)-%b class:%X:%X name:%s",
+                        device.getVendorId(), device.getProductId(),
+                        UsbSerialDevice.isSupported(device),
+                        device.getDeviceClass(), device.getDeviceSubclass(),
+                        device.getDeviceName()));
+            }
+
             for (Map.Entry<String, UsbDevice> entry : usbDevices.entrySet()) {
                 device = entry.getValue();
                 int deviceVID = device.getVendorId();
                 int devicePID = device.getProductId();
 
-                if (deviceVID != 0x1d6b && (devicePID != 0x0001 && devicePID != 0x0002 && devicePID != 0x0003) && deviceVID != 0x5c6 && devicePID != 0x904c) {
-              
-                    // There is a device connected to our Android device. Try to open it as a Serial Port.
+//                if (deviceVID != 0x1d6b && (devicePID != 0x0001 && devicePID != 0x0002 && devicePID != 0x0003) && deviceVID != 0x5c6 && devicePID != 0x904c) {
+                if (UsbSerialDevice.isSupported(device)) {
+                    // There is a supported device connected - request permission to access it.
                     requestUserPermission();
-                    keep = false;
+                    break;
                 } else {
                     connection = null;
                     device = null;
                 }
-
-                if (!keep)
-                    break;
             }
-            if (!keep) {
-                // There is no USB devices connected (but usb host were listed). Send an intent to MainActivity.
+            if (device==null) {
+                // There are no USB devices connected (but usb host were listed). Send an intent to MainActivity.
                 Intent intent = new Intent(ACTION_NO_USB);
                 sendBroadcast(intent);
             }
         } else {
+            Log.d(TAG, "findSerialPortDevice() usbManager returned empty device list." );
             // There is no USB devices connected. Send an intent to MainActivity
             Intent intent = new Intent(ACTION_NO_USB);
             sendBroadcast(intent);
@@ -218,6 +226,7 @@ public class UsbService extends Service {
      * Request user permission. The response will be received in the BroadcastReceiver
      */
     private void requestUserPermission() {
+        Log.d(TAG, String.format("requestUserPermission(%X:%X)", device.getVendorId(), device.getProductId() ) );
         PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
         usbManager.requestPermission(device, mPendingIntent);
     }

--- a/example/src/main/java/com/felhr/serialportexample/UsbService.java
+++ b/example/src/main/java/com/felhr/serialportexample/UsbService.java
@@ -12,6 +12,7 @@ import android.hardware.usb.UsbManager;
 import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
+import android.util.Log;
 
 import com.felhr.usbserial.CDCSerialDevice;
 import com.felhr.usbserial.UsbSerialDevice;
@@ -23,6 +24,8 @@ import java.util.Map;
 
 public class UsbService extends Service {
 
+    public static final String TAG = "UsbService";
+    
     public static final String ACTION_USB_READY = "com.felhr.connectivityservices.USB_READY";
     public static final String ACTION_USB_ATTACHED = "android.hardware.usb.action.USB_DEVICE_ATTACHED";
     public static final String ACTION_USB_DETACHED = "android.hardware.usb.action.USB_DEVICE_DETACHED";

--- a/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
+++ b/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
@@ -155,30 +155,39 @@ public class UsbService extends Service {
         // This snippet will try to open the first encountered usb device connected, excluding usb root hubs
         HashMap<String, UsbDevice> usbDevices = usbManager.getDeviceList();
         if (!usbDevices.isEmpty()) {
-            boolean keep = true;
+            
+            // first, dump the map for diagnostic purposes
+            for (Map.Entry<String, UsbDevice> entry : usbDevices.entrySet()) {
+                device = entry.getValue();
+                Log.d(TAG, String.format("USBDevice.HashMap (vid:pid) (%X:%X)-%b class:%X:%X name:%s",
+                        device.getVendorId(), device.getProductId(),
+                        UsbSerialDevice.isSupported(device),
+                        device.getDeviceClass(), device.getDeviceSubclass(),
+                        device.getDeviceName()));
+            }
+
             for (Map.Entry<String, UsbDevice> entry : usbDevices.entrySet()) {
                 device = entry.getValue();
                 int deviceVID = device.getVendorId();
                 int devicePID = device.getProductId();
 
-                if (deviceVID != 0x1d6b && (devicePID != 0x0001 && devicePID != 0x0002 && devicePID != 0x0003)) {
+//                if (deviceVID != 0x1d6b && (devicePID != 0x0001 && devicePID != 0x0002 && devicePID != 0x0003)) {
+                if (UsbSerialDevice.isSupported(device)) {
                     // There is a device connected to our Android device. Try to open it as a Serial Port.
                     requestUserPermission();
-                    keep = false;
+                    break;
                 } else {
                     connection = null;
                     device = null;
                 }
-
-                if (!keep)
-                    break;
             }
-            if (!keep) {
-                // There is no USB devices connected (but usb host were listed). Send an intent to MainActivity.
+            if (device==null) {
+                // There are no USB devices connected (but usb host were listed). Send an intent to MainActivity.
                 Intent intent = new Intent(ACTION_NO_USB);
                 sendBroadcast(intent);
             }
         } else {
+            Log.d(TAG, "findSerialPortDevice() usbManager returned empty device list." );
             // There is no USB devices connected. Send an intent to MainActivity
             Intent intent = new Intent(ACTION_NO_USB);
             sendBroadcast(intent);
@@ -197,6 +206,7 @@ public class UsbService extends Service {
      * Request user permission. The response will be received in the BroadcastReceiver
      */
     private void requestUserPermission() {
+        Log.d(TAG, String.format("requestUserPermission(%X:%X)", device.getVendorId(), device.getProductId() ) );
         PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
         usbManager.requestPermission(device, mPendingIntent);
     }

--- a/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
+++ b/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
@@ -12,6 +12,7 @@ import android.hardware.usb.UsbManager;
 import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
+import android.util.Log;
 
 import com.felhr.usbserial.CDCSerialDevice;
 import com.felhr.usbserial.SerialInputStream;
@@ -25,6 +26,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class UsbService extends Service {
 
+    public static final String TAG = "UsbService";
+    
     public static final String ACTION_USB_READY = "com.felhr.connectivityservices.USB_READY";
     public static final String ACTION_USB_ATTACHED = "android.hardware.usb.action.USB_DEVICE_ATTACHED";
     public static final String ACTION_USB_DETACHED = "android.hardware.usb.action.USB_DEVICE_DETACHED";

--- a/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
+++ b/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
@@ -12,6 +12,7 @@ import android.hardware.usb.UsbManager;
 import android.os.Binder;
 import android.os.Handler;
 import android.os.IBinder;
+import android.util.Log;
 
 import com.felhr.usbserial.CDCSerialDevice;
 import com.felhr.usbserial.UsbSerialDevice;
@@ -22,6 +23,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class UsbService extends Service {
+
+    public static final String TAG = "UsbService";
 
     public static final String ACTION_USB_READY = "com.felhr.connectivityservices.USB_READY";
     public static final String ACTION_USB_ATTACHED = "android.hardware.usb.action.USB_DEVICE_ATTACHED";

--- a/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
+++ b/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
@@ -185,30 +185,39 @@ public class UsbService extends Service {
         // This snippet will try to open the first encountered usb device connected, excluding usb root hubs
         HashMap<String, UsbDevice> usbDevices = usbManager.getDeviceList();
         if (!usbDevices.isEmpty()) {
-            boolean keep = true;
+            
+            // first, dump the map for diagnostic purposes
+            for (Map.Entry<String, UsbDevice> entry : usbDevices.entrySet()) {
+                device = entry.getValue();
+                Log.d(TAG, String.format("USBDevice.HashMap (vid:pid) (%X:%X)-%b class:%X:%X name:%s",
+                        device.getVendorId(), device.getProductId(),
+                        UsbSerialDevice.isSupported(device),
+                        device.getDeviceClass(), device.getDeviceSubclass(),
+                        device.getDeviceName()));
+            }
+
             for (Map.Entry<String, UsbDevice> entry : usbDevices.entrySet()) {
                 device = entry.getValue();
                 int deviceVID = device.getVendorId();
                 int devicePID = device.getProductId();
 
-                if (deviceVID != 0x1d6b && (devicePID != 0x0001 && devicePID != 0x0002 && devicePID != 0x0003)) {
+//                if (deviceVID != 0x1d6b && (devicePID != 0x0001 && devicePID != 0x0002 && devicePID != 0x0003)) {
+                if (UsbSerialDevice.isSupported(device)) {
                     // There is a device connected to our Android device. Try to open it as a Serial Port.
                     requestUserPermission();
-                    keep = false;
+                    break;
                 } else {
                     connection = null;
                     device = null;
                 }
-
-                if (!keep)
-                    break;
             }
-            if (!keep) {
+            if (device==null) {
                 // There is no USB devices connected (but usb host were listed). Send an intent to MainActivity.
                 Intent intent = new Intent(ACTION_NO_USB);
                 sendBroadcast(intent);
             }
         } else {
+            Log.d(TAG, "findSerialPortDevice() usbManager returned empty device list." );
             // There is no USB devices connected. Send an intent to MainActivity
             Intent intent = new Intent(ACTION_NO_USB);
             sendBroadcast(intent);
@@ -227,6 +236,7 @@ public class UsbService extends Service {
      * Request user permission. The response will be received in the BroadcastReceiver
      */
     private void requestUserPermission() {
+        Log.d(TAG, String.format("requestUserPermission(%X:%X)", device.getVendorId(), device.getProductId() ) );
         PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
         usbManager.requestPermission(device, mPendingIntent);
     }


### PR DESCRIPTION
The hashmap returned by usbManager.getDeviceList() contains devices in random order. These changes ensure that access is requested for the first _supported_ device. This fixes an issue when other devices are present, and would sometimes appear ahead of the USB/Serial device in the hashmap, so access was requested for the _wrong_ device.

Other changes add key diagnostic information to the log for debugging purposes.