### PR TITLE
Refactored so that all common thread methods are handled in a base class

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/AbstractWorkerThread.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/AbstractWorkerThread.java
@@ -1,0 +1,18 @@
+package com.felhr.usbserial;
+
+/* package */ abstract class AbstractWorkerThread extends Thread {
+    boolean firstTime = true;
+    private volatile boolean keep = true;
+
+    void stopThread() {
+        keep = false;
+    }
+
+    public final void run() {
+        while (keep) {
+            doRun();
+        }
+    }
+
+    abstract void doRun();
+}

--- a/usbserial/src/main/java/com/felhr/usbserial/BLED112SerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/BLED112SerialDevice.java
@@ -41,10 +41,9 @@ public class BLED112SerialDevice extends UsbSerialDevice
     private static final int BLED112_DEFAULT_CONTROL_LINE = 0x0003;
     private static final int BLED112_DISCONNECT_CONTROL_LINE = 0x0002;
 
-    private UsbInterface mInterface;
+    private final UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
-    private UsbRequest requestIN;
 
     @Deprecated
     public BLED112SerialDevice(UsbDevice device, UsbDeviceConnection connection)
@@ -88,7 +87,7 @@ public class BLED112SerialDevice extends UsbSerialDevice
         setControlCommand(BLED112_SET_CONTROL_LINE_STATE, BLED112_DEFAULT_CONTROL_LINE, null);
 
         // Initialize UsbRequest
-        requestIN = new UsbRequest();
+        UsbRequest requestIN = new UsbRequest();
         requestIN.initialize(connection, inEndpoint);
 
         // Pass references to the threads

--- a/usbserial/src/main/java/com/felhr/usbserial/CDCSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CDCSerialDevice.java
@@ -46,10 +46,9 @@ public class CDCSerialDevice extends UsbSerialDevice
     private static final int CDC_CONTROL_LINE_ON = 0x0003;
     private static final int CDC_CONTROL_LINE_OFF = 0x0000;
 
-    private UsbInterface mInterface;
+    private final UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
-    private UsbRequest requestIN;
 
     private int initialBaudRate = 0;
 
@@ -84,7 +83,7 @@ public class CDCSerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new SafeUsbRequest();
+            UsbRequest requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/CH34xSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CH34xSerialDevice.java
@@ -16,8 +16,6 @@ import android.util.Log;
 
 import com.felhr.utils.SafeUsbRequest;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class CH34xSerialDevice extends UsbSerialDevice
 {
     private static final String CLASS_ID = CH34xSerialDevice.class.getSimpleName();
@@ -85,7 +83,6 @@ public class CH34xSerialDevice extends UsbSerialDevice
     private UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
-    private UsbRequest requestIN;
 
     private FlowControlThread flowControlThread;
     private UsbCTSCallback ctsCallback;
@@ -118,7 +115,7 @@ public class CH34xSerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new SafeUsbRequest();
+            UsbRequest requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface
@@ -609,66 +606,48 @@ public class CH34xSerialDevice extends UsbSerialDevice
         }
     }
 
-    private class FlowControlThread extends Thread
+    private class FlowControlThread extends AbstractWorkerThread
     {
-        private long time = 100; // 100ms
-
-        private boolean firstTime;
-
-        private AtomicBoolean keep;
-
-        public FlowControlThread()
-        {
-            keep = new AtomicBoolean(true);
-            firstTime = true;
-        }
+        private final long time = 100; // 100ms
 
         @Override
-        public void run()
+        public void doRun()
         {
-            while(keep.get())
+            if(!firstTime)
             {
-                if(!firstTime)
+                // Check CTS status
+                if(rtsCtsEnabled)
                 {
-                    // Check CTS status
-                    if(rtsCtsEnabled)
+                    boolean cts = pollForCTS();
+                    if(ctsState != cts)
                     {
-                        boolean cts = pollForCTS();
-                        if(ctsState != cts)
-                        {
-                            ctsState = !ctsState;
-                            if (ctsCallback != null)
-                                ctsCallback.onCTSChanged(ctsState);
-                        }
+                        ctsState = !ctsState;
+                        if (ctsCallback != null)
+                            ctsCallback.onCTSChanged(ctsState);
                     }
-
-                    // Check DSR status
-                    if(dtrDsrEnabled)
-                    {
-                        boolean dsr = pollForDSR();
-                        if(dsrState != dsr)
-                        {
-                            dsrState = !dsrState;
-                            if (dsrCallback != null)
-                                dsrCallback.onDSRChanged(dsrState);
-                        }
-                    }
-                }else
-                {
-                    if(rtsCtsEnabled && ctsCallback != null)
-                        ctsCallback.onCTSChanged(ctsState);
-
-                    if(dtrDsrEnabled && dsrCallback != null)
-                        dsrCallback.onDSRChanged(dsrState);
-
-                    firstTime = false;
                 }
-            }
-        }
 
-        public void stopThread()
-        {
-            keep.set(false);
+                // Check DSR status
+                if(dtrDsrEnabled)
+                {
+                    boolean dsr = pollForDSR();
+                    if(dsrState != dsr)
+                    {
+                        dsrState = !dsrState;
+                        if (dsrCallback != null)
+                            dsrCallback.onDSRChanged(dsrState);
+                    }
+                }
+            }else
+            {
+                if(rtsCtsEnabled && ctsCallback != null)
+                    ctsCallback.onCTSChanged(ctsState);
+
+                if(dtrDsrEnabled && dsrCallback != null)
+                    dsrCallback.onDSRChanged(dsrState);
+
+                firstTime = false;
+            }
         }
 
         public boolean pollForCTS()

--- a/usbserial/src/main/java/com/felhr/usbserial/CP2130SpiDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/CP2130SpiDevice.java
@@ -11,7 +11,7 @@ import android.util.Log;
 
 public class CP2130SpiDevice extends UsbSpiDevice
 {
-    private static String CLASS_ID = CP2130SpiDevice.class.getSimpleName();
+    private static final String CLASS_ID = CP2130SpiDevice.class.getSimpleName();
 
     public static final int CLOCK_12MHz = 0;
     public static final int CLOCK_6MHz = 1;
@@ -29,7 +29,7 @@ public class CP2130SpiDevice extends UsbSpiDevice
     private static final int SET_GPIO_CHIP_SELECT = 0x25;
     private static final int GET_SPI_WORD = 0x30;
 
-    private UsbInterface mInterface;
+    private final UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
     private UsbRequest requestIN;

--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -79,10 +79,9 @@ public class FTDISerialDevice extends UsbSerialDevice
     private UsbCTSCallback ctsCallback;
     private UsbDSRCallback dsrCallback;
 
-    private UsbInterface mInterface;
+    private final UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
-    private UsbRequest requestIN;
 
     public FTDIUtilities ftdiUtilities;
 
@@ -117,7 +116,7 @@ public class FTDISerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new SafeUsbRequest();
+            UsbRequest requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/PL2303SerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/PL2303SerialDevice.java
@@ -22,7 +22,7 @@ public class PL2303SerialDevice extends UsbSerialDevice
     private static final int PL2303_SET_LINE_CODING = 0x20;
     private static final int PL2303_SET_CONTROL_REQUEST = 0x22;
 
-    private byte[] defaultSetLine = new byte[]{
+    private final byte[] defaultSetLine = new byte[]{
             (byte) 0x80, // [0:3] Baud rate (reverse hex encoding 9600:00 00 25 80 -> 80 25 00 00)
             (byte) 0x25,
             (byte) 0x00,
@@ -33,10 +33,9 @@ public class PL2303SerialDevice extends UsbSerialDevice
     };
 
 
-    private UsbInterface mInterface;
+    private final UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
-    private UsbRequest requestIN;
 
 
     public PL2303SerialDevice(UsbDevice device, UsbDeviceConnection connection)
@@ -64,7 +63,7 @@ public class PL2303SerialDevice extends UsbSerialDevice
         if(ret)
         {
             // Initialize UsbRequest
-            requestIN = new SafeUsbRequest();
+            UsbRequest requestIN = new SafeUsbRequest();
             requestIN.initialize(connection, inEndpoint);
 
             // Restart the working thread if it has been killed before and  get and claim interface

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -9,7 +9,7 @@ public class SerialBuffer
     public static final int DEFAULT_READ_BUFFER_SIZE = 16 * 1024;
     public static final int DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
     private ByteBuffer readBuffer;
-    private SynchronizedBuffer writeBuffer;
+    private final SynchronizedBuffer writeBuffer;
     private byte[] readBuffer_compatible; // Read buffer for android < 4.2
     private boolean debugging = false;
 
@@ -107,7 +107,7 @@ public class SerialBuffer
 
     private class SynchronizedBuffer
     {
-        private byte[] buffer;
+        private final byte[] buffer;
         private int position;
 
         public SynchronizedBuffer()

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialInputStream.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialInputStream.java
@@ -9,7 +9,7 @@ public class SerialInputStream extends InputStream
 
     private int maxBufferSize =  16 * 1024;
 
-    private byte[] buffer;
+    private final byte[] buffer;
     private int pointer;
     private int bufferSize;
 

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -1,7 +1,5 @@
 package com.felhr.usbserial;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import com.felhr.deviceids.CH34xIds;
 import com.felhr.deviceids.CP210xIds;
 import com.felhr.deviceids.FTDISioIds;
@@ -22,10 +20,9 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
     public static final String FTDI = "ftdi";
     public static final String PL2303 = "pl2303";
 
-    private static final String CLASS_ID = UsbSerialDevice.class.getSimpleName();
     protected static final String COM_PORT = "COM ";
 
-    private static boolean mr1Version;
+    private static final boolean mr1Version;
     protected final UsbDevice device;
     protected final UsbDeviceConnection connection;
 
@@ -304,52 +301,47 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
     /*
      * WorkerThread waits for request notifications from IN endpoint
      */
-    protected class WorkerThread extends Thread
+    protected class WorkerThread extends AbstractWorkerThread
     {
-        private UsbSerialDevice usbSerialDevice;
+        private final UsbSerialDevice usbSerialDevice;
 
         private UsbReadCallback callback;
         private UsbRequest requestIN;
-        private AtomicBoolean working;
 
         public WorkerThread(UsbSerialDevice usbSerialDevice)
         {
             this.usbSerialDevice = usbSerialDevice;
-            working = new AtomicBoolean(true);
         }
 
         @Override
-        public void run()
+        public void doRun()
         {
-            while(working.get())
+            UsbRequest request = connection.requestWait();
+            if(request != null && request.getEndpoint().getType() == UsbConstants.USB_ENDPOINT_XFER_BULK
+                    && request.getEndpoint().getDirection() == UsbConstants.USB_DIR_IN)
             {
-                UsbRequest request = connection.requestWait();
-                if(request != null && request.getEndpoint().getType() == UsbConstants.USB_ENDPOINT_XFER_BULK
-                        && request.getEndpoint().getDirection() == UsbConstants.USB_DIR_IN)
+                byte[] data = serialBuffer.getDataReceived();
+
+                // FTDI devices reserves two first bytes of an IN endpoint with info about
+                // modem and Line.
+                if(isFTDIDevice())
                 {
-                    byte[] data = serialBuffer.getDataReceived();
+                    ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.checkModemStatus(data); //Check the Modem status
+                    serialBuffer.clearReadBuffer();
 
-                    // FTDI devices reserves two first bytes of an IN endpoint with info about
-                    // modem and Line.
-                    if(isFTDIDevice())
+                    if(data.length > 2)
                     {
-                        ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.checkModemStatus(data); //Check the Modem status
-                        serialBuffer.clearReadBuffer();
-
-                        if(data.length > 2)
-                        {
-                            data = ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.adaptArray(data);
-                            onReceivedData(data);
-                        }
-                    }else
-                    {
-                        // Clear buffer, execute the callback
-                        serialBuffer.clearReadBuffer();
+                        data = ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.adaptArray(data);
                         onReceivedData(data);
                     }
-                    // Queue a new request
-                    requestIN.queue(serialBuffer.getReadBuffer(), SerialBuffer.DEFAULT_READ_BUFFER_SIZE);
+                }else
+                {
+                    // Clear buffer, execute the callback
+                    serialBuffer.clearReadBuffer();
+                    onReceivedData(data);
                 }
+                // Queue a new request
+                requestIN.queue(serialBuffer.getReadBuffer(), SerialBuffer.DEFAULT_READ_BUFFER_SIZE);
             }
         }
 
@@ -373,57 +365,36 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
             if(callback != null)
                 callback.onReceivedData(data);
         }
-
-        public void stopWorkingThread()
-        {
-            working.set(false);
-        }
     }
 
-    protected class WriteThread extends Thread
+    private class WriteThread extends AbstractWorkerThread
     {
         private UsbEndpoint outEndpoint;
-        private AtomicBoolean working;
-
-        public WriteThread()
-        {
-            working = new AtomicBoolean(true);
-        }
 
         @Override
-        public void run()
+        public void doRun()
         {
-            while(working.get())
-            {
-                byte[] data = serialBuffer.getWriteBuffer();
-                if(data.length > 0)
-                    connection.bulkTransfer(outEndpoint, data, data.length, USB_TIMEOUT);
-            }
+            byte[] data = serialBuffer.getWriteBuffer();
+            if(data.length > 0)
+                connection.bulkTransfer(outEndpoint, data, data.length, USB_TIMEOUT);
         }
 
         public void setUsbEndpoint(UsbEndpoint outEndpoint)
         {
             this.outEndpoint = outEndpoint;
         }
-
-        public void stopWriteThread()
-        {
-            working.set(false);
-        }
     }
 
-    protected class ReadThread extends Thread
+    protected class ReadThread extends AbstractWorkerThread
     {
-        private UsbSerialDevice usbSerialDevice;
+        private final UsbSerialDevice usbSerialDevice;
 
         private UsbReadCallback callback;
         private UsbEndpoint inEndpoint;
-        private AtomicBoolean working;
 
         public ReadThread(UsbSerialDevice usbSerialDevice)
         {
             this.usbSerialDevice = usbSerialDevice;
-            working = new AtomicBoolean(true);
         }
 
         public void setCallback(UsbReadCallback callback)
@@ -432,38 +403,34 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
         }
 
         @Override
-        public void run()
+        public void doRun()
         {
             byte[] dataReceived = null;
+            int numberBytes;
+            if(inEndpoint != null)
+                numberBytes = connection.bulkTransfer(inEndpoint, serialBuffer.getBufferCompatible(),
+                        SerialBuffer.DEFAULT_READ_BUFFER_SIZE, 0);
+            else
+                numberBytes = 0;
 
-            while(working.get())
+            if(numberBytes > 0)
             {
-                int numberBytes;
-                if(inEndpoint != null)
-                    numberBytes = connection.bulkTransfer(inEndpoint, serialBuffer.getBufferCompatible(),
-                            SerialBuffer.DEFAULT_READ_BUFFER_SIZE, 0);
-                else
-                    numberBytes = 0;
+                dataReceived = serialBuffer.getDataReceivedCompatible(numberBytes);
 
-                if(numberBytes > 0)
+                // FTDI devices reserve two first bytes of an IN endpoint with info about
+                // modem and Line.
+                if(isFTDIDevice())
                 {
-                    dataReceived = serialBuffer.getDataReceivedCompatible(numberBytes);
+                    ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.checkModemStatus(dataReceived);
 
-                    // FTDI devices reserve two first bytes of an IN endpoint with info about
-                    // modem and Line.
-                    if(isFTDIDevice())
+                    if(dataReceived.length > 2)
                     {
-                        ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.checkModemStatus(dataReceived);
-
-                        if(dataReceived.length > 2)
-                        {
-                            dataReceived = ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.adaptArray(dataReceived);
-                            onReceivedData(dataReceived);
-                        }
-                    }else
-                    {
+                        dataReceived = ((FTDISerialDevice) usbSerialDevice).ftdiUtilities.adaptArray(dataReceived);
                         onReceivedData(dataReceived);
                     }
+                }else
+                {
+                    onReceivedData(dataReceived);
                 }
             }
         }
@@ -471,11 +438,6 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
         public void setUsbEndpoint(UsbEndpoint inEndpoint)
         {
             this.inEndpoint = inEndpoint;
-        }
-
-        public void stopReadThread()
-        {
-            working.set(false);
         }
 
         private void onReceivedData(byte[] data)
@@ -511,11 +473,11 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
     {
         if(mr1Version && workerThread != null)
         {
-            workerThread.stopWorkingThread();
+            workerThread.stopThread();
             workerThread = null;
         }else if(!mr1Version && readThread != null)
         {
-            readThread.stopReadThread();
+            readThread.stopThread();
             readThread = null;
         }
     }
@@ -542,7 +504,7 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
     {
         if(writeThread != null)
         {
-            writeThread.stopWriteThread();
+            writeThread.stopThread();
             writeThread = null;
             serialBuffer.resetWriteBuffer();
         }

--- a/usbserial/src/main/java/com/felhr/usbserial/XdcVcpSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/XdcVcpSerialDevice.java
@@ -49,10 +49,9 @@ public class XdcVcpSerialDevice extends UsbSerialDevice
     private static final int XDCVCP_XOFF = 0x0000;
     private static final int DEFAULT_BAUDRATE = 115200;
 
-    private UsbInterface mInterface;
+    private final UsbInterface mInterface;
     private UsbEndpoint inEndpoint;
     private UsbEndpoint outEndpoint;
-    private UsbRequest requestIN;
 
     public XdcVcpSerialDevice(UsbDevice device, UsbDeviceConnection connection)
     {
@@ -110,7 +109,7 @@ public class XdcVcpSerialDevice extends UsbSerialDevice
             return false;
 
         // Initialize UsbRequest
-        requestIN = new UsbRequest();
+        UsbRequest requestIN = new UsbRequest();
         requestIN.initialize(connection, inEndpoint);
 
         // Pass references to the threads


### PR DESCRIPTION
After this commit, common functionality for threads are gathered in a base class.
Less code, removed AtomicBoolean since it can be replaced with a volatile boolean, eliminating an allocation

Some members are made final