### PR TITLE
Reduce garbage by reading usb data right into the buffer on api >= jellybean

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -9,7 +9,6 @@ import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbRequest;
-import android.os.Build;
 import android.util.Log;
 
 import com.felhr.utils.SafeUsbRequest;

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -22,7 +22,9 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
 
     protected static final String COM_PORT = "COM ";
 
-    private static final boolean mr1Version;
+    // Android version < 4.3 It is not going to be asynchronous read operations
+    static final boolean mr1Version =
+            android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
     protected final UsbDevice device;
     protected final UsbDeviceConnection connection;
 
@@ -46,15 +48,6 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
 
     private String portName = "";
     protected boolean isOpen;
-
-    // Get Android version if version < 4.3 It is not going to be asynchronous read operations
-    static
-    {
-        if(android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.JELLY_BEAN_MR1)
-            mr1Version = true;
-        else
-            mr1Version = false;
-    }
 
     public UsbSerialDevice(UsbDevice device, UsbDeviceConnection connection)
     {
@@ -455,14 +448,13 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
 
     protected void setThreadsParams(UsbRequest request, UsbEndpoint endpoint)
     {
+        writeThread.setUsbEndpoint(endpoint);
         if(mr1Version)
         {
             workerThread.setUsbRequest(request);
-            writeThread.setUsbEndpoint(endpoint);
         }else
         {
             readThread.setUsbEndpoint(request.getEndpoint());
-            writeThread.setUsbEndpoint(endpoint);
         }
     }
 


### PR DESCRIPTION
I have not tried this yet, but if you can, that would be great. 
This patch utilizes the newer apis where you can read directly into a buffer.
The adaptArray dance will not be necessary anymore. I will try this tonight and see how it fares.