### PR TITLE
Fix Write Thread does not stop when close port

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/AbstractWorkerThread.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/AbstractWorkerThread.java
@@ -3,13 +3,21 @@ package com.felhr.usbserial;
 abstract class AbstractWorkerThread extends Thread {
     boolean firstTime = true;
     private volatile boolean keep = true;
+    private volatile Thread workingThread;
 
     void stopThread() {
         keep = false;
+        if (this.workingThread != null) {
+            this.workingThread.interrupt();
+        }
     }
 
     public final void run() {
-        while (keep) {
+        if (!this.keep) {
+            return;
+        }
+        this.workingThread = Thread.currentThread();
+        while (this.keep && (!this.workingThread.isInterrupted())) {
             doRun();
         }
     }

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialBuffer.java
@@ -118,6 +118,7 @@ public class SerialBuffer
                 } catch (InterruptedException e)
                 {
                     e.printStackTrace();
+                    Thread.currentThread().interrupt();
                 }
             }
             byte[] dst;


### PR DESCRIPTION
Fix WriteThread `serialBuffer.getWriteBuffer()` can not stop because SynchronizedBuffer was locked by  `wait()`  and not release