### PR TITLE
added chunked stream methods

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/SerialInputStream.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialInputStream.java
@@ -55,6 +55,18 @@ public class SerialInputStream extends InputStream
     }
 
     @Override
+    public int read(byte b[], int off, int len)
+    {
+        if (off == 0 && len == b.length) {
+            return read(b);
+        }
+        byte[] slice = new byte[len];
+        int ret = device.syncRead(slice, timeout);
+        System.arraycopy(slice, 0, b, off, ret);
+        return ret;
+    }
+
+    @Override
     public int available() throws IOException {
         if(bufferSize > 0)
             return bufferSize - pointer;

--- a/usbserial/src/main/java/com/felhr/usbserial/SerialOutputStream.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/SerialOutputStream.java
@@ -25,6 +25,18 @@ public class SerialOutputStream extends OutputStream
         device.syncWrite(b, timeout);
     }
 
+    @Override
+    public void write(byte b[], int off, int len)
+    {
+        if (off == 0 && len == b.length) {
+            write(b);
+            return;
+        }
+        byte[] slice = new byte[len];
+        System.arraycopy(b, off, slice, 0, len);
+        device.syncWrite(slice, timeout);
+    }
+
     public void setTimeout(int timeout) {
         this.timeout = timeout;
     }


### PR DESCRIPTION
A lack of implementation of the array slice methods on SerialInputStream/SerialOutputStream was causing any users of those methods to use the single-byte implementations, causing a `bulkTransfer` to get called for every individual byte, which in addition to being bad for performance was causing communication problems with my device. 

This PR implements those methods by creating appropriate array slices.