### PR TITLE
Reassign Microchip pid:vid 04d8:000a from FTDI -> CDC

### DIFF
--- a/usbserial/src/main/java/com/felhr/deviceids/FTDISioIds.java
+++ b/usbserial/src/main/java/com/felhr/deviceids/FTDISioIds.java
@@ -251,7 +251,6 @@ public class FTDISioIds
             createDevice(0x03eb, 0x2109),
             createDevice(0x0456, 0xf000),
             createDevice(0x0456, 0xf001),
-            createDevice(0x04d8, 0x000a),
             createDevice(0x0584, 0xb020),
             createDevice(0x0647, 0x0100),
             createDevice(0x06CE, 0x8311),


### PR DESCRIPTION
According to the Linux kernel tree [1], Microchip pid:vid 04d8:000a
is generally a CDC ACM device, implemented by a demo firmware
application.

However, some vendors have re-used this vid:pid for other types of
firmware, emulating FTDI chips. The Linux kernel attempts to detect
such cases by matching on interface class/subclass/proto. If these
are ff/ff/00 it uses FTDI, otherwise CDC.

Given that current library code cannot do such matching, we should
re-assign the pid:vid to CDC, as this is correct in the majority
of cases.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f08dea734844aa42ec57c229b0b73b3d7d21f810

Signed-off-by: Sven Van Asbroeck <TheSven73@gmail.com>