### PR TITLE
ftdi: Fix bcdDevice endian

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -786,7 +786,7 @@ public class FTDISerialDevice extends UsbSerialDevice
     private short getBcdDevice() {
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
             byte[] descriptors = connection.getRawDescriptors();
-            return (short) ((descriptors[12] << 8) + descriptors[13]);
+            return (short) ((descriptors[13] << 8) + descriptors[12]);
         }else{
             return -1;
         }


### PR DESCRIPTION
USB descriptor values are in little endian. I got bcdDevice 0x0010 instead of 0x1000 (10.00).
