### PR TITLE
ftdi: Fix baudrate setting on multiport devices

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -895,7 +895,7 @@ public class FTDISerialDevice extends UsbSerialDevice
 
     private void setEncodedBaudRate(short[] encodedBaudRate) {
         connection.controlTransfer(FTDI_REQTYPE_HOST2DEVICE, FTDI_SIO_SET_BAUD_RATE
-                , encodedBaudRate[0], encodedBaudRate[1], null, 0, USB_TIMEOUT);
+                , encodedBaudRate[0], encodedBaudRate[1] | (mInterface.getId() + 1), null, 0, USB_TIMEOUT);
     }
 
     private void setOldBaudRate(int baudRate) {


### PR DESCRIPTION
On version 6.1.0, FT2232H baud rates are set incorrectly. There should be ORed bits of the interface number.