### PR TITLE
Fix FTDI array-ouf-of-bounds crash

### DIFF
--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -495,15 +495,11 @@ public class FTDISerialDevice extends UsbSerialDevice
         int length = ftdiData.length;
         if(length > 64)
         {
-            int n = 1;
-            int p = 64;
             // Precalculate length without FTDI headers
-            while(p < length)
-            {
-                n++;
-                p = n*64;
-            }
-            int realLength = length - n*2;
+            int realLength = (length / 64) * 62;
+            if (length % 64 > 2)
+                realLength += length % 64 - 2;
+
             byte[] data = new byte[realLength];
             copyData(ftdiData, data);
             return data;
@@ -529,7 +525,7 @@ public class FTDISerialDevice extends UsbSerialDevice
             dstPos += 62;
         }
         int remaining = src.length - srcPos + 2;
-        if (remaining > 0)
+        if (remaining > 2)
         {
             System.arraycopy(src, srcPos, dst, dstPos, remaining - 2);
         }

--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -563,7 +563,7 @@ public class FTDISerialDevice extends UsbSerialDevice
 
         public void checkModemStatus(byte[] data)
         {
-            if(data.length == 0) // Safeguard for zero length arrays
+            if(data.length < 2) // Safeguard for zero length arrays
                 return;
 
             boolean cts = (data[0] & 0x10) == 0x10;

--- a/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/FTDISerialDevice.java
@@ -537,30 +537,6 @@ public class FTDISerialDevice extends UsbSerialDevice
 
     public class FTDIUtilities
     {
-        // Special treatment needed to FTDI devices
-        public byte[] adaptArray(byte[] ftdiData)
-        {
-            int length = ftdiData.length;
-            if(length > 64)
-            {
-                int n = 1;
-                int p = 64;
-                // Precalculate length without FTDI headers
-                while(p < length)
-                {
-                    n++;
-                    p = n*64;
-                }
-                int realLength = length - n*2;
-                byte[] data = new byte[realLength];
-                copyData(ftdiData, data);
-                return data;
-            }else
-            {
-                return Arrays.copyOfRange(ftdiData, 2, length);
-            }
-        }
-
         public void checkModemStatus(byte[] data)
         {
             if(data.length < 2) // Safeguard for zero length arrays
@@ -674,7 +650,7 @@ public class FTDISerialDevice extends UsbSerialDevice
 
             if(numberBytes > 2) // Data received
             {
-                byte[] newBuffer = this.ftdiUtilities.adaptArray(tempBuffer);
+                byte[] newBuffer = adaptArray(tempBuffer);
                 System.arraycopy(newBuffer, 0, buffer, 0, buffer.length);
 
                 int p = numberBytes / 64;
@@ -731,7 +707,7 @@ public class FTDISerialDevice extends UsbSerialDevice
 
             if(numberBytes > 2) // Data received
             {
-                byte[] newBuffer = this.ftdiUtilities.adaptArray(tempBuffer);
+                byte[] newBuffer = adaptArray(tempBuffer);
                 System.arraycopy(newBuffer, 0, buffer, offset, length);
 
                 int p = numberBytes / 64;

--- a/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
+++ b/usbserial/src/main/java/com/felhr/usbserial/UsbSerialDevice.java
@@ -356,7 +356,7 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
 
                     if(data.length > 2)
                     {
-                        data = FTDISerialDevice.adaptArray(data);
+                        data = ((FTDISerialDevice) usbSerialDevice).adaptArray(data);
                         onReceivedData(data);
                     }
                 }else
@@ -450,7 +450,7 @@ public abstract class UsbSerialDevice implements UsbSerialInterface
 
                     if(dataReceived.length > 2)
                     {
-                        dataReceived = FTDISerialDevice.adaptArray(dataReceived);
+                        dataReceived = ((FTDISerialDevice) usbSerialDevice).adaptArray(dataReceived);
                         onReceivedData(dataReceived);
                     }
                 }else


### PR DESCRIPTION
Crash happens when bad data (odd length) was received from the USB device. See commit messages for details.