### PR TITLE
fix: compatibility with android 12 and up

### DIFF
--- a/example/src/main/java/com/felhr/serialportexample/UsbService.java
+++ b/example/src/main/java/com/felhr/serialportexample/UsbService.java
@@ -230,8 +230,10 @@ public class UsbService extends Service {
      * Request user permission. The response will be received in the BroadcastReceiver
      */
     private void requestUserPermission() {
+        int flag = (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) ? PendingIntent.FLAG_MUTABLE : 0;
+        
         Log.d(TAG, String.format("requestUserPermission(%X:%X)", device.getVendorId(), device.getProductId() ) );
-        PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
+        PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), flag);
         usbManager.requestPermission(device, mPendingIntent);
     }
 

--- a/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
+++ b/examplestreams/src/main/java/com/felhr/examplestreams/UsbService.java
@@ -210,8 +210,10 @@ public class UsbService extends Service {
      * Request user permission. The response will be received in the BroadcastReceiver
      */
     private void requestUserPermission() {
+        int flag = (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) ? PendingIntent.FLAG_MUTABLE : 0;
+        
         Log.d(TAG, String.format("requestUserPermission(%X:%X)", device.getVendorId(), device.getProductId() ) );
-        PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
+        PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), flag);
         usbManager.requestPermission(device, mPendingIntent);
     }
 

--- a/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
+++ b/examplesync/src/main/java/com/felhr/serialportexamplesync/UsbService.java
@@ -240,8 +240,10 @@ public class UsbService extends Service {
      * Request user permission. The response will be received in the BroadcastReceiver
      */
     private void requestUserPermission() {
+        int flag = (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) ? PendingIntent.FLAG_MUTABLE : 0;
+        
         Log.d(TAG, String.format("requestUserPermission(%X:%X)", device.getVendorId(), device.getProductId() ) );
-        PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
+        PendingIntent mPendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), flag);
         usbManager.requestPermission(device, mPendingIntent);
     }
 


### PR DESCRIPTION
This pull request contains a fix for a crash I discovered when the application was asking to access the USB interface with an android version greater than or equal to 12. 

Indeed, it was missing the update of the new Android security and the setting of a special flag for this kind of case.

I have also performed tests to ensure that the fix did not cause any other problems and that everything works as expected.
Thanks for considering this pull request.