### PR TITLE
Added id 067b:23c3 Prolific Technology, Inc. USB-Serial Controller

### DIFF
--- a/usbserial/src/main/java/com/felhr/deviceids/PL2303Ids.java
+++ b/usbserial/src/main/java/com/felhr/deviceids/PL2303Ids.java
@@ -13,6 +13,7 @@ public class PL2303Ids
     private static final long[] pl2303Devices = createTable(
             createDevice(0x04a5, 0x4027),
             createDevice(0x067b, 0x2303),
+            createDevice(0x067b, 0x23c3),
             createDevice(0x067b, 0x04bb),
             createDevice(0x067b, 0x1234),
             createDevice(0x067b, 0xaaa0),


### PR DESCRIPTION

```
$ lsusb -v -d 067b:23c3

Bus 003 Device 033: ID 067b:23c3 Prolific Technology, Inc. USB-Serial Controller 
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0 
  bDeviceSubClass         0 
  bDeviceProtocol         0 
  bMaxPacketSize0        64
  idVendor           0x067b Prolific Technology, Inc.
  idProduct          0x23c3 
  bcdDevice            3.05
  iManufacturer           1 Prolific Technology Inc. 
  iProduct                2 USB-Serial Controller 
  iSerial                 3 CKAPh10CD20
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x0027
    bNumInterfaces          1
    bConfigurationValue     1
    iConfiguration          0 
    bmAttributes         0xa0
      (Bus Powered)
      Remote Wakeup
    MaxPower              100mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           3
      bInterfaceClass       255 Vendor Specific Class
      bInterfaceSubClass      0 
      bInterfaceProtocol      0 
      iInterface              0 
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x000a  1x 10 bytes
        bInterval               1
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x02  EP 2 OUT
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               0
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x83  EP 3 IN
        bmAttributes            2
          Transfer Type            Bulk
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               0
Device Status:     0x0000
  (Bus Powered)


```